### PR TITLE
Update to keymap-drawer 0.6.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 argparse = "1.4.0"
-keymap-drawer = "0.4.0"
+keymap-drawer = "0.6.0"
 pcpp = "1.30"
 pyyaml = "6.0"
 qmk = "1.1.1"

--- a/scripts/json2yaml
+++ b/scripts/json2yaml
@@ -14,20 +14,8 @@ layout_h="$2"
 # (4) Parse fully expanded QMK keymap.json into yaml using keymap-drawer
 qmk json2c "$keymap_json" -o /tmp/keymap-json.c 2> /dev/null 
 pcpp -D QMK_KEYBOARD_H="" -D KEYMAP_DISPLAY $layout_h /tmp/keymap-json.c > /tmp/keymap.c
-qmk c2json -kb "$(jq -r '.keyboard' $keymap_json)" -km default /tmp/keymap.c > /tmp/keymap.json 
-keymap parse -q /tmp/keymap.json > "$keymap_yaml"
-
-# Handle held keys
-perl -i -pe "s|\bHELD\b|{type: held}|g" "$keymap_yaml"
-
-# Restore layer names using layer macro names in keymap.json 
-i=0
+qmk c2json -kb "$(jq -r '.keyboard' $keymap_json)" -km default /tmp/keymap.c > /tmp/keymap.json
 layers=$(jq -cr ".layers[][0]" $keymap_json | sed 's|\s*\_||g')
-for name in $layers; do
-    perl -i -pe "s|\bL$i\b|$name|g" "$keymap_yaml"  # yaml layer names
-    perl -i -pe "s|\($i\)|($name)|g" "$keymap_yaml" # keycode refs (eg: MO, OSL, etc)
-    perl -i -pe "s|t: '$i', h: sticky|t: '$name', h: sticky|g" "$keymap_yaml" # OSL
-    let i=${i}+1
-done
+keymap parse -l $layers -q /tmp/keymap.json > "$keymap_yaml"
 
 cat "$keymap_yaml"


### PR DESCRIPTION
Hey 👋 I made some improvements to parsing recently at https://github.com/caksoylar/keymap-drawer/releases/tag/v0.6.0, partially with your script in mind. I updated `json2yaml` to use the two new features related to layer names and automatic held key parsing. As a consequence you can likely remove `_HELD_` keys from your layout at https://github.com/jbarr21/qmk_userspace/blob/main/layout.h#L63. (I haven't checked your ZMK config to see if you use this tool there.)

I think lock file might also need updating but I haven't touched it.